### PR TITLE
Add Open in Browser variable to config.js

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,5 +1,7 @@
 export const PORT = 3000;
 
+export const OPEN_IN_BROWSER = true;
+
 export const SELECTED_BINDING = 'alpaca-cpp' || 'node-llama';
 export const CHAT_SETTINGS_ALPACA_CPP = {
     ctx_size: 2048,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,5 +1,5 @@
 import {App} from '@tinyhttp/app';
-import {PORT} from './config.js';
+import {OPEN_IN_BROWSER, PORT} from './config.js';
 import {activateChat} from './chat.js';
 import {cors} from '@tinyhttp/cors';
 import sirv from 'sirv';
@@ -22,4 +22,4 @@ ws.on('connection', activateChat);
 const listenPort = await getPort({port: PORT});
 const browserURL = `http://127.0.0.1:${listenPort}`;
 server.listen(listenPort, () => console.log(`Listening on ${browserURL}`));
-PRODUCTION && tryCatch(() => openurl.open(browserURL));
+(PRODUCTION && OPEN_IN_BROWSER) && tryCatch(() => openurl.open(browserURL));


### PR DESCRIPTION
# Add Open in Browser config variable

## Changes

- Added `OPEN_IN_BROWSER` to config.js (defaults to `true`)
- Change open in browser conditional in `index.js` to include `OPEN_IN_BROWSER`

## Note

I wanted to run CatAI in a docker container. The `tryCatch` that the open function is wrapped in does not successfully prevent the program from crashing. Adding the variable to the config should make it so that people can prevent the browser from being opened in these types of use cases
