### PR TITLE
fix(cli): uninstall & migration

### DIFF
--- a/server/src/cli/commands/uninstall.ts
+++ b/server/src/cli/commands/uninstall.ts
@@ -13,7 +13,5 @@ uninstallCommand.description('Uninstall server and delete all models')
 
         await $`npm uninstall -g catai`;
         await fs.remove(ENV_CONFIG.CATAI_DIR!);
-
-        const newVersion = (await $`catai --version`).stdout.trim();
-        spinner.succeed('CatAI uninstalled: ' + newVersion);
+            spinner.succeed('CatAI uninstalled');
     });

--- a/server/src/cli/commands/uninstall.ts
+++ b/server/src/cli/commands/uninstall.ts
@@ -13,5 +13,5 @@ uninstallCommand.description('Uninstall server and delete all models')
 
         await $`npm uninstall -g catai`;
         await fs.remove(ENV_CONFIG.CATAI_DIR!);
-            spinner.succeed('CatAI uninstalled');
+        spinner.succeed('CatAI uninstalled');
     });

--- a/server/src/storage/config.ts
+++ b/server/src/storage/config.ts
@@ -1,8 +1,8 @@
-import * as path from "path";
-import * as os from "os";
-import yn from "yn";
-import fs from "fs-extra";
-import {fileURLToPath} from "url";
+import * as path from 'path';
+import * as os from 'os';
+import yn from 'yn';
+import fs from 'fs-extra';
+import {fileURLToPath} from 'url';
 
 const __dirname = fileURLToPath(new URL('./', import.meta.url));
 export const packageJSON = await fs.readJSON(path.join(__dirname, '..', '..', 'package.json'));
@@ -93,7 +93,7 @@ function mergeConfig() {
 
 async function main() {
     mergeConfig();
-    await fs.ensureDir(ENV_CONFIG.CATAI_DIR!);
+    await fs.ensureDir(ENV_CONFIG.MODEL_DIR!);
 }
 
 await main();


### PR DESCRIPTION
### Description of change

Fix issue #36 
- Problem with the migration process between the older version of catai - does not create the model's directory if it does not exist.
- Uninstall command - throw error after success uninstall

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended to correct.

  In some cases, it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged, it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all the following items:

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained
  in [CONTRIBUTING.md](https://github.com/withcatai/catai/blob/master/CONTRIBUTING.md)
